### PR TITLE
Adiciona o Mumble Server como comunicador

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Compilação de informações destinada a quem trabalha ou quer trabalhar remota
 - [IRCCloud](https://www.irccloud.com/)
 - [Skype](http://www.skype.com/)
 - [Rocket Chat](https://rocket.chat/)
-- [Self Hosted Mumble](https://wiki.mumble.info/wiki/Main_Page)
+- [Self Hosted Mumble](https://www.mumble.info/)
 
 ### Produtividade
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Compilação de informações destinada a quem trabalha ou quer trabalhar remota
 - [IRCCloud](https://www.irccloud.com/)
 - [Skype](http://www.skype.com/)
 - [Rocket Chat](https://rocket.chat/)
+- [Self Hosted Mumble](https://wiki.mumble.info/wiki/Main_Page)
 
 ### Produtividade
 


### PR DESCRIPTION
Nas duas empresas onde trabalhei remoto (Titans e atualmente olist.com) experimentamos dezenas de ferramentas para audio/video conferência (sem exagero). A única que funcionou perfeitamente e aguentou mais de 50 pessoas em uma mesma sala foi o Mumble rodando em uma instância EC2 em SP.

Ele funciona somente com áudio (o que percebemos ser uma boa característica para melhorar o foco nas reuniões) e permite criação de salas com permissões específicas.

O único incoveniente dele é que os clientes são feiosos e pouco amigáveis para o uso por leigos.