### PR TITLE
Atualiza link Estudo da universidade de Stanford

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Compilação de informações destinada a quem trabalha ou quer trabalhar remota
 - [Remote](http://37signals.com/remote) (Livro - Jason Fried e DHH)
 - [Trabalho Remoto - Small Office, Home Office (SoHo)](http://www.akitaonrails.com/2013/11/18/off-topic-trabalho-remoto-small-office-home-office-soho) (Fábio Akita)
 - [tapajos/trabalhando_fora](https://github.com/tapajos/trabalhando_fora)
-- [Estudo da universidade Stanford sobre WFH](https://web.stanford.edu/~nbloom/WFH.pdf)
+- [Estudo da universidade Stanford sobre WFH](https://web.archive.org/web/20170725133932/https://people.stanford.edu/nbloom/sites/default/files/wfh.pdf)
 
 ### Grok Podcast
 - [Episódio 86 – Trabalho Remoto – Parte 1 de 5](http://www.grokpodcast.com/2013/04/02/episodio-86-trabalho-remoto-parte-1-de-4/)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Compilação de informações destinada a quem trabalha ou quer trabalhar remota
 ## Empregos
 
 ### TI
-- [Remote-friendly companies](https://github.com/jessicard/remote-jobs)
+- Remote-friendly companies
+   - [Remote Jobs](https://github.com/jessicard/remote-jobs)
+   - [Awesome Remote Job](https://github.com/lukasz-madon/awesome-remote-job)
+   - [200+ Startups hiring remotely](https://docs.google.com/spreadsheets/d/1TLJSlNxCbwRNxy14Toe1PYwbCTY7h0CNHeer9J0VRzE/edit#gid=0)
 - [Stack Overflow Careers](http://careers.stackoverflow.com/jobs/remote)
 - [We Work Remotely](https://weworkremotely.com)
 - [AngelList](https://angel.co/jobs#find/f!%7B%22remote%22%3Atrue%7D)

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ Compilação de informações destinada a quem trabalha ou quer trabalhar remota
 ## Empregos
 
 ### TI
-- Remote-friendly companies
-   - [Remote Jobs](https://github.com/jessicard/remote-jobs)
-   - [Awesome Remote Job](https://github.com/lukasz-madon/awesome-remote-job)
-   - [200+ Startups hiring remotely](https://docs.google.com/spreadsheets/d/1TLJSlNxCbwRNxy14Toe1PYwbCTY7h0CNHeer9J0VRzE/edit#gid=0)
 - [Stack Overflow Careers](http://careers.stackoverflow.com/jobs/remote)
 - [We Work Remotely](https://weworkremotely.com)
 - [AngelList](https://angel.co/jobs#find/f!%7B%22remote%22%3Atrue%7D)
@@ -52,6 +48,10 @@ Compilação de informações destinada a quem trabalha ou quer trabalhar remota
 ### Diversos
 - [trampos.co](http://trampos.co/oportunidades?lc=home%20office)
 - [Worldpackers](https://www.worldpackers.com/)
+
+### Empresas "remote-friendly"
+- [Jessicard Remote Jobs](https://github.com/jessicard/remote-jobs)
+- [200+ Startups hiring remotely](https://docs.google.com/spreadsheets/d/1TLJSlNxCbwRNxy14Toe1PYwbCTY7h0CNHeer9J0VRzE/edit#gid=0)
 
 ## Ferramentas
 
@@ -84,6 +84,7 @@ Compilação de informações destinada a quem trabalha ou quer trabalhar remota
 - [Trabalho Remoto - Small Office, Home Office (SoHo)](http://www.akitaonrails.com/2013/11/18/off-topic-trabalho-remoto-small-office-home-office-soho) (Fábio Akita)
 - [tapajos/trabalhando_fora](https://github.com/tapajos/trabalhando_fora)
 - [Estudo da universidade Stanford sobre WFH](https://web.archive.org/web/20170725133932/https://people.stanford.edu/nbloom/sites/default/files/wfh.pdf)
+- [Awesome Remote Jobs](https://github.com/lukasz-madon/awesome-remote-job)
 
 ### Grok Podcast
 - [Episódio 86 – Trabalho Remoto – Parte 1 de 5](http://www.grokpodcast.com/2013/04/02/episodio-86-trabalho-remoto-parte-1-de-4/)


### PR DESCRIPTION
O link sobre o estudo WFH não abria o pdf. Então salvei documento no WaybackMachine e atualizei o link aqui. Assim não perdemos o pdf :)

Adicionei também 2 novos links que mostram mais algumas empresas remote-friendly.