### PR TITLE
Proposta de alteração de fluxo de convites para o Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Compilação de informações destinada a quem trabalha ou quer trabalhar remota
 - [tapajos/trabalhando_fora](https://github.com/tapajos/trabalhando_fora)
 - [Estudo da universidade Stanford sobre WFH](https://web.archive.org/web/20170725133932/https://people.stanford.edu/nbloom/sites/default/files/wfh.pdf)
 - [Awesome Remote Jobs](https://github.com/lukasz-madon/awesome-remote-job)
-- [Slack Trabalho Remoto (BR)](https://trabalho-remoto.slack.com) (Abra uma issue para pedir o link de convite atualizado)
+- [Slack Trabalho Remoto (BR)](https://trabalho-remoto.slack.com) (Poste seu email [nessa discussão](https://github.com/DyegoCosta/trabalhando-remoto/discussions/128) para que outros possam te convidar para o Slack)
 
 ### Grok Podcast
 - [Episódio 86 – Trabalho Remoto – Parte 1 de 5](https://www.grokpodcast.com.br/2013/04/02/episodio-86-trabalho-remoto-parte-1-de-4/)


### PR DESCRIPTION
Na minha opinião, é melhor que as pessoas postem o e-mail e sejam convidadas (2 ações), do que pedirem o link, alguém gerar o link e elas entrarem depois (3 ações).