### PR TITLE
Update of TransferWise to Wise

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Não leve em consideração somente as cotações para escolher o banco ideal pa
 - [Google Pay](https://pay.google.com/about/)
 - [Western Union](https://www.westernunion.com.br)
 - [Xoom](https://www.xoom.com/)
-- [TransferWise](https://transferwise.com/)
+- [Wise](https://wise.com/)
 - [Husky](https://husky.io/)
 
 ### Invoice


### PR DESCRIPTION
TransferWise renamed itself to just "Wise", also replacing all links and references. This PR set the correct link.